### PR TITLE
File name during upload needs to be encoded

### DIFF
--- a/hup.js
+++ b/hup.js
@@ -360,7 +360,7 @@
 
         this.xhr.open(this.options.type, this.options.url, this.options.async);
         this.xhr.setRequestHeader('Accept', 'application/json');
-        this.xhr.setRequestHeader('X-File-Name', this.file.name);
+        this.xhr.setRequestHeader('X-File-Name', encodeURIComponent(this.file.name));
         this.xhr.setRequestHeader('X-File-Type', this.file.type);
 
         if (this.options.chunked)


### PR DESCRIPTION
Added encodeURIComponent to file name because if you use non latin chars (such as Greek chars) it produces error.

In the php class we must add urldecode